### PR TITLE
Update Acrobat Reader package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# acrobat_reader
+
+This file is used to list changes made in each version of the acrobat_reader cookbook.
+
+## 0.1.3
+
+- Update Name for Acrobat Reader
+
+## 0.1.2
+
+- Public with new license agreement
+
+## 0.1.1
+
+- Add package checksum
+
+## 0.1.0
+
+- Initial release

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,5 +3,5 @@ maintainer         'Eastbound Tech'
 maintainer_email   'tim@eastbound.io'
 license            'Apache-2.0'
 description        'Installs/Configures acrobat_reader'
-version            '0.1.2'
+version            '0.1.3'
 chef_version       '>= 12.1' if respond_to?(:chef_version)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: acrobat_reader
 # Recipe:: default
 
-windows_package 'Acrobat Reader' do
+windows_package 'Adobe Acrobat Reader DC' do
   source 'https://storage.googleapis.com/chef_files/acrobat_reader.exe'
   checksum 'B0F41F680387EBFD2919D059EBD535FF7E9E29D2AB3E273065F6726C516DBB9E'
   action :install


### PR DESCRIPTION
Update the correct name for the Acrobat Reader installation package. This brings idempotency for converging systems.